### PR TITLE
fix repository url

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/panoply/shopify-sync/shopify-sync.git"
+    "url": "git://github.com/panoply/shopify-sync.git"
   },
   "bugs": {
     "url": "https://github.com/panoply/shopify-sync/issues"


### PR DESCRIPTION
noticed the typo when running `npm repo shopify-sync`